### PR TITLE
Refactor linear_combination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ark-bls12-381"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/curves#f74378c0177ca8e5b53989b1197ddaf7325115c0"
+source = "git+https://github.com/arkworks-rs/curves#363426c1d41aa89c8e64bc4fd265b7cefe24fb03"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#4d485734751a887caffda8c8c75147ab796d8922"
+source = "git+https://github.com/arkworks-rs/algebra#aabe76c584b97c92c07c005e2d5297ce53e9d597"
 dependencies = [
  "ark-ff",
  "ark-poly",
@@ -52,7 +52,7 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#4d485734751a887caffda8c8c75147ab796d8922"
+source = "git+https://github.com/arkworks-rs/algebra#aabe76c584b97c92c07c005e2d5297ce53e9d597"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
@@ -71,7 +71,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#4d485734751a887caffda8c8c75147ab796d8922"
+source = "git+https://github.com/arkworks-rs/algebra#aabe76c584b97c92c07c005e2d5297ce53e9d597"
 dependencies = [
  "quote",
  "syn",
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#4d485734751a887caffda8c8c75147ab796d8922"
+source = "git+https://github.com/arkworks-rs/algebra#aabe76c584b97c92c07c005e2d5297ce53e9d597"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -99,7 +99,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "clap 3.2.20",
+ "clap 3.2.22",
  "criterion",
  "env_logger",
  "hashbrown",
@@ -115,7 +115,7 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#4d485734751a887caffda8c8c75147ab796d8922"
+source = "git+https://github.com/arkworks-rs/algebra#aabe76c584b97c92c07c005e2d5297ce53e9d597"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -128,7 +128,7 @@ dependencies = [
 [[package]]
 name = "ark-relations"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/snark?branch=sync-algebra#b3bf732b06d96de29c62854cdaca6e4bbe464708"
+source = "git+https://github.com/arkworks-rs/snark?branch=sync-algebra#bc575ab0c967e29e049608029cf9f09c981d6654"
 dependencies = [
  "ark-ff",
  "ark-std",
@@ -139,7 +139,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#4d485734751a887caffda8c8c75147ab796d8922"
+source = "git+https://github.com/arkworks-rs/algebra#aabe76c584b97c92c07c005e2d5297ce53e9d597"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#4d485734751a887caffda8c8c75147ab796d8922"
+source = "git+https://github.com/arkworks-rs/algebra#aabe76c584b97c92c07c005e2d5297ce53e9d597"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -159,7 +159,7 @@ dependencies = [
 [[package]]
 name = "ark-std"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/utils#05b7a19a99551bdd737eb2ffb1c9eac7be0dd11f"
+source = "git+https://github.com/arkworks-rs/utils#7019830e89b69aca059ce7848e53bd99a09efbab"
 dependencies = [
  "colored",
  "num-traits",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -251,7 +251,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap 0.15.1",
 ]
 
 [[package]]
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "crypto-common",
 ]
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
 dependencies = [
  "either",
 ]
@@ -529,9 +529,9 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -586,7 +586,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -668,9 +668,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716b4eeb6c4a1d3ecc956f75b43ec2e8e8ba80026413e70a3f41fd3313d3492b"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -762,7 +762,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -772,7 +772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -783,9 +783,9 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -852,7 +852,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.13",
+ "semver 1.0.14",
 ]
 
 [[package]]
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "semver-parser"
@@ -943,9 +943,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -984,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "tinytemplate"
@@ -1036,21 +1036,21 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "valuable"
@@ -1083,9 +1083,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1093,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -1108,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1131,15 +1131,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1200,4 +1200,4 @@ dependencies = [
 [[patch.unused]]
 name = "ark-test-curves"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#4d485734751a887caffda8c8c75147ab796d8922"
+source = "git+https://github.com/arkworks-rs/algebra#aabe76c584b97c92c07c005e2d5297ce53e9d597"

--- a/benches/coreops_bench.rs
+++ b/benches/coreops_bench.rs
@@ -13,7 +13,6 @@ use ark_bls12_381::G1Projective as G1;
 use ark_ec::ProjectiveCurve;
 use ark_ff::fields::PrimeField;
 
-
 fn bench_add(c: &mut Criterion) {
     let rng = &mut test_rng();
     let mut group = c.benchmark_group("add");

--- a/src/kzg/mod.rs
+++ b/src/kzg/mod.rs
@@ -94,7 +94,7 @@ pub use time::CommitterKey;
 #[cfg(test)]
 pub mod tests;
 
-use ark_ec::{pairing::Pairing, AffineRepr, VariableBaseMSM};
+use ark_ec::{pairing::Pairing, VariableBaseMSM};
 use ark_ff::{Field, One, Zero};
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
 use ark_serialize::*;
@@ -224,7 +224,7 @@ impl<E: Pairing> VerifierKey<E> {
             .iter()
             .map(|e| interpolate_poly::<E>(eval_points, e, &sca_inverse, &lang).coeffs)
             .collect::<Vec<_>>();
-        let i_poly = linear_combination(&interpolated_polynomials[..], &etas).unwrap();
+        let i_poly = linear_combination(&interpolated_polynomials[..], &etas);
 
         let i_comm = E::G1::msm(&self.powers_of_g, &i_poly);
 

--- a/src/kzg/space.rs
+++ b/src/kzg/space.rs
@@ -2,7 +2,6 @@
 use ark_ec::pairing::Pairing;
 use ark_ec::scalar_mul::variable_base::{ChunkedPippenger, HashMapPippenger};
 use ark_ec::CurveGroup;
-use ark_ec::VariableBaseMSM;
 use ark_ff::{PrimeField, Zero};
 use ark_poly::Polynomial;
 use ark_std::borrow::Borrow;

--- a/src/kzg/time.rs
+++ b/src/kzg/time.rs
@@ -154,8 +154,7 @@ impl<E: Pairing> CommitterKey<E> {
     ) -> EvaluationProof<E> {
         assert!(eval_points.len() < self.powers_of_g2.len());
         let etas = powers(*eval_chal, polynomials.len());
-        let batched_polynomial =
-            linear_combination(polynomials, &etas).unwrap_or_else(|| vec![E::ScalarField::zero()]);
+        let batched_polynomial = linear_combination(polynomials, &etas);
         self.open_multi_points(&batched_polynomial, eval_points)
     }
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -34,7 +34,7 @@ pub fn ceil_div(x: usize, y: usize) -> usize {
 }
 
 /// Compute a linear combination of the polynomials `polynomials` with the given challenges.
-pub fn linear_combination<F: Field, PP>(polynomials: &[PP], challenges: &[F]) -> Option<Vec<F>>
+pub fn linear_combination<F: Field, PP>(polynomials: &[PP], challenges: &[F]) -> Vec<F>
 where
     PP: Borrow<Vec<F>>,
 {
@@ -42,9 +42,9 @@ where
         .iter()
         .zip(challenges.iter())
         .map(|(p, &c)| &DensePolynomial::from_coefficients_vec(p.borrow().to_vec()) * c)
-        .reduce(|x, y| x + y)?
-        .coeffs
-        .into()
+        .reduce(|x, y| x + y)
+        .map(|x| x.coeffs.into())
+        .unwrap_or_else(|| Vec::new())
 }
 
 /// Helper function for folding single polynomial.
@@ -394,8 +394,8 @@ fn test_linear_combination() {
         Fr::from(1102),
         Fr::from(1103),
     ];
-    assert!(got.is_some());
-    assert_eq!(got.unwrap(), expected);
+    assert_eq!(got, expected);
+    assert_eq!(linear_combination(&Vec::<Vec<Fr>>::new(), &Vec::<Fr>::new()), Vec::<Fr>::new());
 }
 
 #[test]

--- a/src/psnark/elastic_prover.rs
+++ b/src/psnark/elastic_prover.rs
@@ -1,5 +1,5 @@
 //! Space-efficient preprocessing SNARK for R1CS.
-use ark_ec::{pairing::Pairing};
+use ark_ec::pairing::Pairing;
 use ark_ff::Field;
 use ark_std::borrow::Borrow;
 use ark_std::boxed::Box;

--- a/src/psnark/time_prover.rs
+++ b/src/psnark/time_prover.rs
@@ -118,8 +118,7 @@ impl<E: Pairing> Proof<E> {
                 hadamard(&alpha_star, &val_c),
             ],
             &challenges,
-        )
-        .unwrap();
+        );
 
         let second_sumcheck_time = start_timer!(|| "Second sumcheck");
         let second_proof = Sumcheck::new_time(

--- a/src/subprotocols/tensorcheck/mod.rs
+++ b/src/subprotocols/tensorcheck/mod.rs
@@ -65,8 +65,6 @@ pub mod streams;
 #[cfg(test)]
 pub mod tests;
 
-const EMPTY_CHALLENGES_ERR_MSG: &str = "Empty challenges list";
-
 /// Evaluate a folded polynomial tree at the point `x`.
 ///
 /// Make a single pass over the [`FoldedPolynomialTree`](crate::subprotocols::sumcheck::streams::FoldedPolynomialTree)
@@ -202,10 +200,12 @@ impl<E: Pairing> TensorcheckProof<E> {
 
         let batch_challenge = transcript.get_challenge::<E::ScalarField>(b"batch_challenge");
         let batch_challenges = powers(batch_challenge, max_len);
+        assert_ne!(batch_challenges.len(), 0);
+        assert!(body_polynomials.iter().all(|polynomials| polynomials.0.len() != 0));
 
         let batched_body_polynomials = body_polynomials.iter().map(|(polynomials, challenges)| {
             (
-                linear_combination(polynomials, &batch_challenges).expect(EMPTY_CHALLENGES_ERR_MSG),
+                linear_combination(polynomials, &batch_challenges),
                 challenges,
             )
         });


### PR DESCRIPTION
Return a `Vec<F>` instead of an `Option<Vec<F>>`. In case of an empty input polynomial, return the empty vector. 

Also optimized some imports