### PR TITLE
Fix Cargo.toml ark-relations branch setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ ark-serialize = {git = "https://github.com/arkworks-rs/algebra"}
 ark-serialize-derive = {git = "https://github.com/arkworks-rs/algebra"}
 ark-poly = {git = "https://github.com/arkworks-rs/algebra"}
 ark-bls12-381 = {git = "https://github.com/arkworks-rs/curves"}
-ark-relations = {git = "https://github.com/arkworks-rs/snark", branch = "sync-algebra"}
+ark-relations = {git = "https://github.com/arkworks-rs/snark"}
 
 [dependencies]
 ark-bls12-381 = "0.3.0"


### PR DESCRIPTION
Remove Cargo.toml setting that sources ark-relations from an old deleted branch. A one line change that was supposed to be included in previous commit.