### PR TITLE
Fix incorrect usage of "a" and "an" in comments

### DIFF
--- a/src/subprotocols/sumcheck/time_prover.rs
+++ b/src/subprotocols/sumcheck/time_prover.rs
@@ -186,6 +186,6 @@ fn test_trivial_prover() {
     assert_eq!(prover.f.len(), 1);
     // assert_eq!(prover.f.len()[0], prover.f[0]+ r * prover.f[1]));
 
-    // an subsequent call to the next-message function should return None.
+    // a subsequent call to the next-message function should return None.
     assert!(prover.next_message(None).is_none());
 }

--- a/src/subprotocols/tensorcheck/mod.rs
+++ b/src/subprotocols/tensorcheck/mod.rs
@@ -36,7 +36,7 @@
 //! f(x_0, \dots, x_n) \mapsto f(x, x^2, \dots, x^{2^{n-1}})
 //! $
 //! we are effectively
-//! reducing a multivariate evaluation proof to an univariate tensorcheck.
+//! reducing a multivariate evaluation proof to a univariate tensorcheck.
 //!
 use ark_ec::pairing::Pairing;
 use ark_ff::{Field, AdditiveGroup};


### PR DESCRIPTION
- In **`time_prover.rs`**, the phrase "an subsequent" has been corrected to "a subsequent" to match the rule for using "a" before words that start with a consonant sound.
- In **`mod.rs`**, the phrase "an univariate" has been corrected to "a univariate" for the same reason, as "univariate" starts with a "juː" sound, which is a consonant.